### PR TITLE
[1.0.6] Fix: add abilty for proper work with input references which have spaces between backtick and text

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,7 +889,7 @@ APIReferences uses regular expressions to capture *references* to API methods in
 The default reg-ex is:
 
 ```re
-`((?P<prefix>[\w-]+):\s*)?(?P<verb>OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT|PATCH|LINK|UNLINK)\s+(?P<command>\S+)`
+`(\s*(?P<prefix>[\w-]+):\s*)?(?P<verb>OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT|PATCH|LINK|UNLINK)\s+(?P<command>[^`]+)\s*`
 ```
 
 This expression accepts references like these:
@@ -907,7 +907,7 @@ For example, if you want to capture ONLY references with prefixes, you may use t
 preprocessors:
   - apireferences:
       reference:
-      - regex: '((?P<prefix>[\w-]+):\s*)(?P<verb>POST|GET|PUT|UPDATE|DELETE)\s+(?P<command>\S+)`'
+      - regex: '(\s*(?P<prefix>[\w-]+):\s*)(?P<verb>POST|GET|PUT|UPDATE|DELETE)\s+(?P<command>[^`]+)`\s*'
 ```
 
 > This example is for illustrative purposes only. You can achieve the same goal by just switching on the `only_with_prefixes` option.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.6
+
+- Fix: now the preprocessor works correctly with initial and last spaces in input references like ``` ` Client-API: GET user/info ` ```
+
 # 1.0.5
 
 - New: `use_multiproject_mode` option (default: `True`) to use cached API registries in multiproject

--- a/foliant/preprocessors/apireferences/apireferences.py
+++ b/foliant/preprocessors/apireferences/apireferences.py
@@ -17,9 +17,9 @@ from foliant.preprocessors.utils.preprocessor_ext import allow_fail
 from foliant.utils import output
 
 
-DEFAULT_REF_REGEX = r'`((?P<prefix>[\w-]+):\s*)?' +\
+DEFAULT_REF_REGEX = r'`(\s*(?P<prefix>[\w-]+):\s*)?' +\
                     rf'(?P<verb>{"|".join(HTTP_VERBS)})\s+' +\
-                    r'(?P<command>\S+)`'
+                    r'(?P<command>[^`]+)\s*`'
 DEFAULT_IGNORING_PREFIX = 'Ignore'
 
 DEFAULT_REF_DICT = {

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='1.0.5',
+    version='1.0.6',
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     url='https://github.com/foliant-docs/foliantcontrib.apireferences',

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -26,6 +26,14 @@ class TestReference(TestCase):
         self.assertEqual(ref.verb, 'GET')
         self.assertEqual(ref.command, '/user/status')
 
+    def test_source_with_backtick_spaces(self):
+        source = '` MyAPI: GET /user/status `'
+        pattern = re.compile(DEFAULT_REF_REGEX)
+        match = pattern.search(source)
+        ref = Reference()
+        ref.init_from_match(match)
+        self.assertEqual(ref.source, source)
+
     def test_command_and_ep_slashes(self):
         ref = Reference(
             source='`MyAPI: GET /user/status`',


### PR DESCRIPTION
* feat(apireferences): change regular expression to trim initial and last spaces in input references

* test(test_reference): add test for initial and last spaces in input references

* docs(README): change default reg-ex in "Capturing References" section

* release: update changelog and setup to version 1.0.6