### PR TITLE
fix (1.0.7): incorrect behaviour in case of list items with spaces inside backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,7 +889,7 @@ APIReferences uses regular expressions to capture *references* to API methods in
 The default reg-ex is:
 
 ```re
-`(\s*(?P<prefix>[\w-]+):\s*)?(?P<verb>OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT|PATCH|LINK|UNLINK)\s+(?P<command>[^`]+)\s*`
+`\s*((?P<prefix>[\w-]+):\s*)?(?P<verb>OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT|PATCH|LINK|UNLINK)\s+(?P<command>[^`]+)\s*`
 ```
 
 This expression accepts references like these:
@@ -907,7 +907,7 @@ For example, if you want to capture ONLY references with prefixes, you may use t
 preprocessors:
   - apireferences:
       reference:
-      - regex: '(\s*(?P<prefix>[\w-]+):\s*)(?P<verb>POST|GET|PUT|UPDATE|DELETE)\s+(?P<command>[^`]+)`\s*'
+      - regex: '\s*((?P<prefix>[\w-]+):\s*)(?P<verb>POST|GET|PUT|UPDATE|DELETE)\s+(?P<command>[^`]+)`\s*'
 ```
 
 > This example is for illustrative purposes only. You can achieve the same goal by just switching on the `only_with_prefixes` option.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.7
+
+- Fix: small fix for proper work when input reference is a list item and have initial and last spaces inside
+
 # 1.0.6
 
 - Fix: now the preprocessor works correctly with initial and last spaces in input references like ``` ` Client-API: GET user/info ` ```

--- a/foliant/preprocessors/apireferences/apireferences.py
+++ b/foliant/preprocessors/apireferences/apireferences.py
@@ -17,7 +17,7 @@ from foliant.preprocessors.utils.preprocessor_ext import allow_fail
 from foliant.utils import output
 
 
-DEFAULT_REF_REGEX = r'`(\s*(?P<prefix>[\w-]+):\s*)?' +\
+DEFAULT_REF_REGEX = r'`\s*((?P<prefix>[\w-]+):\s*)?' +\
                     rf'(?P<verb>{"|".join(HTTP_VERBS)})\s+' +\
                     r'(?P<command>[^`]+)\s*`'
 DEFAULT_IGNORING_PREFIX = 'Ignore'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='1.0.6',
+    version='1.0.7',
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     url='https://github.com/foliant-docs/foliantcontrib.apireferences',

--- a/tests/test_apireferences.py
+++ b/tests/test_apireferences.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 from foliant.preprocessors.apireferences.classes import HTTP_VERBS
+from foliant.preprocessors.apireferences.apireferences import DEFAULT_REF_REGEX
 from foliant_test.preprocessor import PreprocessorTestFramework
 from foliant_test.preprocessor import unpack_dir
 from foliant_test.preprocessor import unpack_file_dict
@@ -623,4 +624,62 @@ class TestAPIReferences(TestCase):
             ),
         )
 
+        self.assertEqual(0, count_output_warnings(self.ptf.capturedOutput))
+
+    def test_reference_with_backtick_spaces(self):
+        pattern = DEFAULT_REF_REGEX
+        self.ptf.options = {
+            'reference': [
+                {
+                    'regex': pattern
+                }
+            ],
+            'API': {
+                'H2H3-Api': {
+                    'url': 'http://example.com/',
+                    'mode': 'find_by_anchor',
+                    'anchor_template': 'user content {verb} {command}',
+                    'endpoint_prefix': '/api/v2'
+                }
+            }
+        }
+
+        self.run_with_mock_url(
+            'data/simple_h2h3.html',
+            input_mapping={
+                'input.md': '` GET /user/login `'
+            },
+            expected_mapping={
+                'input.md': '[GET /user/login](http://example.com/#user-content-get-userlogin)'
+            }
+        )
+        self.assertEqual(0, count_output_warnings(self.ptf.capturedOutput))
+
+    def test_reference_with_backtick_spaces_as_a_list_item(self):
+        pattern = DEFAULT_REF_REGEX
+        self.ptf.options = {
+            'reference': [
+                {
+                    'regex': pattern
+                }
+            ],
+            'API': {
+                'H2H3-Api': {
+                    'url': 'http://example.com/',
+                    'mode': 'find_by_anchor',
+                    'anchor_template': 'user content {verb} {command}',
+                    'endpoint_prefix': '/api/v2'
+                }
+            }
+        }
+
+        self.run_with_mock_url(
+            'data/simple_h2h3.html',
+            input_mapping={
+                'input.md': '- ` GET /user/login `'
+            },
+            expected_mapping={
+                'input.md': '- [GET /user/login](http://example.com/#user-content-get-userlogin)'
+            }
+        )
         self.assertEqual(0, count_output_warnings(self.ptf.capturedOutput))

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -26,14 +26,6 @@ class TestReference(TestCase):
         self.assertEqual(ref.verb, 'GET')
         self.assertEqual(ref.command, '/user/status')
 
-    def test_source_with_backtick_spaces(self):
-        source = '` MyAPI: GET /user/status `'
-        pattern = re.compile(DEFAULT_REF_REGEX)
-        match = pattern.search(source)
-        ref = Reference()
-        ref.init_from_match(match)
-        self.assertEqual(ref.source, source)
-
     def test_command_and_ep_slashes(self):
         ref = Reference(
             source='`MyAPI: GET /user/status`',


### PR DESCRIPTION
- fix(apireferences): fix regex to trim initial and last spaces when input reference is a list item
- test(test_apireferences): add tests for initial and last spaces in input references
- docs(README): change default regex in "Capturing References" section
- release: update changelog and setup to version 1.0.7