### PR TITLE
[1.0.7] New: max_endpoint_prefix option for finding the highest available version of API methods

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.8
+
+- New: `max_endpoint_prefix` (default: `False`) option for `find_by_anchor` and `find_by_tag_content` modes. Used to find the highest available version of the API method when API methods have different maximum versions in the documentation.
+
 # 1.0.7
 
 - Fix: small fix for proper work when input reference is a list item and have initial and last spaces inside

--- a/foliant/preprocessors/apireferences/classes.py
+++ b/foliant/preprocessors/apireferences/classes.py
@@ -928,7 +928,7 @@ def get_args_dict(class_, options: Options) -> dict:
     """
     Filter from options all keys which are not in class_.__init__ method
     Also check for all required arguments, otherwise raise BadConfigError.
-    Also check for conflicting settings and raise RuntimeError.
+    Also check for conflicting settings, otherwise raise BadConfigError.
 
     :param class_: API class to be inspected.
     :param options: Options object.

--- a/foliant/preprocessors/apireferences/classes.py
+++ b/foliant/preprocessors/apireferences/classes.py
@@ -64,7 +64,8 @@ class Reference:
             'verb': '',
             'command': '',  # always root
             'endpoint_prefix': '' , # always root; note: endpoint_prefix is only set by API object
-            'endpoint_prefix_list': []
+            'endpoint_prefix_list': [],
+            'max_endpoint_prefix': False  # new attribute for enabling max version search
         }
         self._init_from_dict(kwargs)
 
@@ -214,6 +215,7 @@ class APIByTagContent(APIBase):
                  trim_query: bool = True,
                  endpoint_prefix: str = '',
                  endpoint_prefix_list: list = [],
+                 max_endpoint_prefix: bool = False,
                  tags: list = DEFAULT_TAG_LIST,
                  login: str or None = None,
                  password: str or None = None):
@@ -225,11 +227,21 @@ class APIByTagContent(APIBase):
         self.endpoint_prefix = endpoint_prefix
         self.endpoint_prefix_tmp = endpoint_prefix
         self.endpoint_prefix_list = endpoint_prefix_list
+        self.max_endpoint_prefix = max_endpoint_prefix
         self.login = login
         self.password = password
-
         self.command_in_content = 'command' in self.content_template
         self.check_registry()
+
+        if max_endpoint_prefix and endpoint_prefix:
+            raise RuntimeError(
+                f"Conflicting settings: you cannot use both endpoint_prefix '{endpoint_prefix}' and "
+                f"max_endpoint_prefix: true at the same time. "
+                f"Please choose one of these options. "
+            )
+
+        if self.max_endpoint_prefix and not self.endpoint_prefix_list:
+            logger.warning("max_endpoint_prefix is set to True, but endpoint_prefix_list is empty")
 
     def check_registry(self):
         if self.multiproject:
@@ -280,6 +292,7 @@ class APIByTagContent(APIBase):
         """
 
         logger.debug(f'Getting link for reference {ref} in API {self.name}')
+        ref.max_endpoint_prefix = self.max_endpoint_prefix
         self.check_reference(ref)
         anchor = self.get_anchor_by_reference(ref)  # may throw ReferenceNotFoundError
         return self.gen_full_url(anchor)
@@ -305,14 +318,45 @@ class APIByTagContent(APIBase):
         registry is formed by self.content_template.  First try with `command` from
         the reference, then (if that fails) try removing leading slash from command,
         then (if that fails) try adding self.endpoint_prefix if present.
-
+        
+        If max_endpoint_prefix is True, tries to find the maximum available version
+        for the reference.
+    
         If reference cannot be found — raise ReferenceNotFoundError.
-
+    
         :param ref: Reference object to be found.
-
+    
         :returns: anchor to the referenced method.
         """
-
+        
+        ref.max_endpoint_prefix = self.max_endpoint_prefix
+        
+        if ref.max_endpoint_prefix and self.endpoint_prefix_list:
+            base_command = ref.command.lstrip('/')
+            sorted_prefixes = sorted(self.endpoint_prefix_list, reverse=True, 
+                                    key=lambda p: int(p.strip('/').replace('v', '')) if p.strip('/').replace('v', '').isdigit() else 0)
+            
+            for prefix in sorted_prefixes:
+                temp_ref = Reference(**ref.__dict__)
+                temp_ref.command = f"{prefix}{base_command}"
+                content = self.generate_content_by_reference(temp_ref, False)
+                result = self.registry.get(content)
+                
+                logger.debug(f'Trying content with prefix {prefix}: {content}')
+                
+                if result:
+                    self.endpoint_prefix_tmp = prefix
+                    logger.debug(f'Found anchor with prefix {prefix}: {result}')
+                    return result
+                
+                if self.command_in_content:
+                    content = self.generate_content_by_reference(temp_ref, False, True)
+                    result = self.registry.get(content)
+                    if result:
+                        self.endpoint_prefix_tmp = prefix
+                        logger.debug(f'Found anchor with prefix {prefix} (relative command): {result}')
+                        return result
+        
         content = self.generate_content_by_reference(ref, False)
         result = self.registry.get(content)
         if result:
@@ -330,7 +374,6 @@ class APIByTagContent(APIBase):
                 if result:
                     logger.debug(f'Found anchor: {result}')
                     return result
-
         logger.debug('Not found')
         raise ReferenceNotFoundError(f'Reference {ref.source} not found in API "{self.name}"')
 
@@ -374,6 +417,9 @@ class APIByAnchor(APIBase):
     """
     API class which generates links based on tag id. It parses the url and
     collects ids from specified tag list.
+
+    If max_endpoint_prefix is True, tries to find the maximum available version
+    for the reference.
     """
 
     mode = 'find_by_anchor'
@@ -387,6 +433,7 @@ class APIByAnchor(APIBase):
                  anchor_converter: str = 'pandoc',
                  endpoint_prefix: str = '',
                  endpoint_prefix_list: list = [],
+                 max_endpoint_prefix: bool = False,
                  tags: list = DEFAULT_TAG_LIST,
                  login: str or None = None,
                  password: str or None = None):
@@ -399,11 +446,21 @@ class APIByAnchor(APIBase):
         self.endpoint_prefix = endpoint_prefix
         self.endpoint_prefix_tmp = endpoint_prefix
         self.endpoint_prefix_list = endpoint_prefix_list
+        self.max_endpoint_prefix = max_endpoint_prefix
         self.login = login
         self.password = password
-
         self.command_in_anchor = 'command' in self.anchor_template
         self.check_registry()
+
+        if max_endpoint_prefix and endpoint_prefix:
+            raise RuntimeError(
+                f"Conflicting settings: you cannot use both endpoint_prefix '{endpoint_prefix}' and "
+                f"max_endpoint_prefix: true at the same time. "
+                f"Please choose one of these options. "
+            )
+
+        if self.max_endpoint_prefix and not self.endpoint_prefix_list:
+            logger.warning("max_endpoint_prefix is set to True, but endpoint_prefix_list is empty")
 
     def check_registry(self):
         if self.multiproject:
@@ -452,6 +509,7 @@ class APIByAnchor(APIBase):
         """
 
         logger.debug(f'Getting link for reference {ref} in API {self.name}')
+        ref.max_endpoint_prefix = self.max_endpoint_prefix
         self.check_reference(ref)
         anchor = self.get_anchor_by_reference(ref)  # may throw ReferenceNotFoundError
         return self.gen_full_url(anchor)
@@ -473,18 +531,34 @@ class APIByAnchor(APIBase):
 
     def get_anchor_by_reference(self, ref: Reference) -> str:
         """
-        Get anchor for the reference from self.registry. The search is performed by
-        anchor formatted by self.anchor_template. First try with `command from the
-        reference, then (if that fails), try removing leading slash from command,
-        then (if that fails), try adding self.endpoint_prefix if present.
-
+        Get anchor for the reference from self.registry. If max_endpoint_prefix is True,
+        finds the maximum available version for the reference.
+    
         If reference cannot be found — raise ReferenceNotFoundError.
-
+    
         :param ref: Reference object to be found.
-
+    
         :returns: found version of anchor.
         """
 
+        if ref.max_endpoint_prefix and self.endpoint_prefix_list:
+            base_command = ref.command.lstrip('/')
+            sorted_prefixes = sorted(self.endpoint_prefix_list, reverse=True, 
+                                    key=lambda p: int(p.strip('/').replace('v', '')) if p.strip('/').replace('v', '').isdigit() else 0)
+            
+            for prefix in sorted_prefixes:
+                temp_ref = Reference(**ref.__dict__)
+                temp_ref.command = f"{prefix}{base_command}"
+                temp_anchor = self.generate_anchor_by_reference(temp_ref, False)
+                
+                logger.debug(f'Trying anchor with prefix {prefix}: {temp_anchor}')
+                
+
+                if self.is_in_registry(temp_anchor):
+                    self.endpoint_prefix_tmp = prefix
+                    logger.debug(f'Found anchor with prefix {prefix}: {temp_anchor}')
+                    return temp_anchor
+        
         anchor = self.generate_anchor_by_reference(ref, False)
         if self.is_in_registry(anchor):
             logger.debug(f'Found anchor by reference"{anchor}"')
@@ -499,10 +573,9 @@ class APIByAnchor(APIBase):
                 if self.is_in_registry(anchor):
                     logger.debug(f'Found anchor with endpoint prefix"{anchor}"')
                     return anchor
-
         logger.debug('Not found')
         raise ReferenceNotFoundError(f'Reference {ref.source} not found in API "{self.name}"')
-
+    
     def is_in_registry(self, elem: str) -> bool:
         """
         Search for elem in the registry, return result of the search.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='1.0.7',
+    version='1.0.8',
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     url='https://github.com/foliant-docs/foliantcontrib.apireferences',

--- a/tests/data/simple_h2h3.html
+++ b/tests/data/simple_h2h3.html
@@ -34,5 +34,33 @@ quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
 cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
 proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <h2 id="user-content-get-v1userinfo">GET /v1/user/info</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <h2 id="user-content-get-v2userinfo">GET /v2/user/info</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <h2 id="user-content-get-v3userinfo">GET /v3/user/info</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <h2 id="user-content-get-systemstatus">GET /system/status</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
   </body>
 </html>

--- a/tests/test_api_by_anchor.py
+++ b/tests/test_api_by_anchor.py
@@ -28,9 +28,15 @@ class TestAPIByAnchor(TestCase):
             )
             self.assertTrue(mock_urlopen.called)
 
-        expected_registry = ['user-content-get-apiv2adminstatus',
-                             'user-content-get-systemrestart',
-                             'user-content-get-userlogin']
+        expected_registry = [
+            'user-content-get-apiv2adminstatus',
+            'user-content-get-systemrestart',
+            'user-content-get-systemstatus',
+            'user-content-get-userlogin',
+            'user-content-get-v1userinfo',
+            'user-content-get-v2userinfo',
+            'user-content-get-v3userinfo'
+        ]
         self.assertEqual(api.registry, expected_registry)
 
     def test_generate_registry_another_tag(self):
@@ -68,9 +74,15 @@ class TestAPIByAnchor(TestCase):
             )
             self.assertTrue(mock_urlopen.called)
 
-        expected_registry = ['user-content-get-apiv2adminstatus',
-                             'user-content-get-systemrestart',
-                             'user-content-get-userlogin']
+        expected_registry = [
+            'user-content-get-apiv2adminstatus',
+            'user-content-get-systemrestart',
+            'user-content-get-systemstatus',
+            'user-content-get-userlogin',
+            'user-content-get-v1userinfo',
+            'user-content-get-v2userinfo',
+            'user-content-get-v3userinfo'
+        ]
         self.assertEqual(api.registry, expected_registry)
 
     def get_basic_api(self):
@@ -220,3 +232,63 @@ class TestAPIByAnchor(TestCase):
         ref = Reference(bar='bar')
         with self.assertRaises(ReferenceNotFoundError):
             api.check_reference(ref)
+
+    def test_get_link_by_reference_max_version(self):
+        with patch('foliant.preprocessors.apireferences.classes.urlopen') as mock_urlopen:
+            with open(rel_name('data/simple_h2h3.html'), 'rb') as f:
+                mock_read = Mock()
+                mock_read.read.return_value = f.read()
+                mock_urlopen.return_value = mock_read
+            api = APIByAnchor(
+                name='Test',
+                url='http://example.com/',
+                multiproject=False,
+                anchor_template='user content {verb} {command}',
+                tags=['h1', 'h2', 'h3'],
+                max_endpoint_prefix=True,
+                endpoint_prefix_list=['/v1/', '/v2/', '/v3/']
+            )
+
+        ref = Reference(verb='GET', command='/user/info')
+        link = api.get_link_by_reference(ref)
+        self.assertEqual(link, 'http://example.com/#user-content-get-v3userinfo')
+
+    def test_get_link_by_reference_max_version_with_explicit_prefix(self):
+        with patch('foliant.preprocessors.apireferences.classes.urlopen') as mock_urlopen:
+            with open(rel_name('data/simple_h2h3.html'), 'rb') as f:
+                mock_read = Mock()
+                mock_read.read.return_value = f.read()
+                mock_urlopen.return_value = mock_read
+            api = APIByAnchor(
+                name='Test',
+                url='http://example.com/',
+                multiproject=False,
+                anchor_template='user content {verb} {command}',
+                tags=['h1', 'h2', 'h3'],
+                max_endpoint_prefix=True,
+                endpoint_prefix_list=['/v1/', '/v2/', '/v3/']
+            )
+
+        ref = Reference(verb='GET', command='/v1/user/info')
+        link = api.get_link_by_reference(ref)
+        self.assertEqual(link, 'http://example.com/#user-content-get-v1userinfo')
+
+    def test_get_link_by_reference_max_version_nonversioned(self):
+        with patch('foliant.preprocessors.apireferences.classes.urlopen') as mock_urlopen:
+            with open(rel_name('data/simple_h2h3.html'), 'rb') as f:
+                mock_read = Mock()
+                mock_read.read.return_value = f.read()
+                mock_urlopen.return_value = mock_read
+            api = APIByAnchor(
+                name='Test',
+                url='http://example.com/',
+                multiproject=False,
+                anchor_template='user content {verb} {command}',
+                tags=['h1', 'h2', 'h3'],
+                max_endpoint_prefix=True,
+                endpoint_prefix_list=['/v1/', '/v2/', '/v3/']
+            )
+
+        ref = Reference(verb='GET', command='/system/status')
+        link = api.get_link_by_reference(ref)
+        self.assertEqual(link, 'http://example.com/#user-content-get-systemstatus')

--- a/tests/test_api_by_tag_content.py
+++ b/tests/test_api_by_tag_content.py
@@ -32,6 +32,10 @@ class TestAPIByTagContent(TestCase):
             'GET /user/login': 'user-content-get-userlogin',
             'GET /api/v2/admin/status': 'user-content-get-apiv2adminstatus',
             'GET /system/restart': 'user-content-get-systemrestart',
+            'GET /system/status': 'user-content-get-systemstatus',
+            'GET /v1/user/info': 'user-content-get-v1userinfo',
+            'GET /v2/user/info': 'user-content-get-v2userinfo',
+            'GET /v3/user/info': 'user-content-get-v3userinfo'
         }
         self.assertEqual(api.registry, expected_registry)
 
@@ -76,6 +80,10 @@ class TestAPIByTagContent(TestCase):
             'GET /user/login': 'user-content-get-userlogin',
             'GET /api/v2/admin/status': 'user-content-get-apiv2adminstatus',
             'GET /system/restart': 'user-content-get-systemrestart',
+            'GET /system/status': 'user-content-get-systemstatus',
+            'GET /v1/user/info': 'user-content-get-v1userinfo',
+            'GET /v2/user/info': 'user-content-get-v2userinfo',
+            'GET /v3/user/info': 'user-content-get-v3userinfo'
         }
         self.assertEqual(api.registry, expected_registry)
 
@@ -217,3 +225,63 @@ class TestAPIByTagContent(TestCase):
         ref = Reference(bar='bar')
         with self.assertRaises(ReferenceNotFoundError):
             api.check_reference(ref)
+
+    def test_get_anchor_by_reference_max_version(self):
+        with patch('foliant.preprocessors.apireferences.classes.urlopen') as mock_urlopen:
+            with open(rel_name('data/simple_h2h3.html'), 'rb') as f:
+                mock_read = Mock()
+                mock_read.read.return_value = f.read()
+                mock_urlopen.return_value = mock_read
+            api = APIByTagContent(
+                name='Test',
+                url='http://example.com/',
+                multiproject=False,
+                content_template='{verb} {command}',
+                tags=['h1', 'h2', 'h3'],
+                max_endpoint_prefix=True,
+                endpoint_prefix_list=['/v1/', '/v2/', '/v3/']
+            )
+
+        ref = Reference(verb='GET', command='/user/info')
+        anchor = api.get_anchor_by_reference(ref)
+        self.assertEqual(anchor, 'user-content-get-v3userinfo')
+
+    def test_get_anchor_by_reference_max_version_with_explicit_prefix(self):
+        with patch('foliant.preprocessors.apireferences.classes.urlopen') as mock_urlopen:
+            with open(rel_name('data/simple_h2h3.html'), 'rb') as f:
+                mock_read = Mock()
+                mock_read.read.return_value = f.read()
+                mock_urlopen.return_value = mock_read
+            api = APIByTagContent(
+                name='Test',
+                url='http://example.com/',
+                multiproject=False,
+                content_template='{verb} {command}',
+                tags=['h1', 'h2', 'h3'],
+                max_endpoint_prefix=True,
+                endpoint_prefix_list=['/v1/', '/v2/', '/v3/']
+            )
+
+        ref = Reference(verb='GET', command='/v1/user/info')
+        anchor = api.get_anchor_by_reference(ref)
+        self.assertEqual(anchor, 'user-content-get-v1userinfo')
+
+    def test_get_anchor_by_reference_max_version_nonversioned(self):
+        with patch('foliant.preprocessors.apireferences.classes.urlopen') as mock_urlopen:
+            with open(rel_name('data/simple_h2h3.html'), 'rb') as f:
+                mock_read = Mock()
+                mock_read.read.return_value = f.read()
+                mock_urlopen.return_value = mock_read
+            api = APIByTagContent(
+                name='Test',
+                url='http://example.com/',
+                multiproject=False,
+                content_template='{verb} {command}',
+                tags=['h1', 'h2', 'h3'],
+                max_endpoint_prefix=True,
+                endpoint_prefix_list=['/v1/', '/v2/', '/v3/']
+            )
+
+        ref = Reference(verb='GET', command='/system/status')
+        anchor = api.get_anchor_by_reference(ref)
+        self.assertEqual(anchor, 'user-content-get-systemstatus')

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -5,7 +5,6 @@ from foliant.preprocessors.apireferences.classes import WrongModeError
 from foliant.preprocessors.apireferences.classes import get_api
 from unittest import TestCase
 
-
 def rel_name(path: str):
     return os.path.join(os.path.dirname(__file__), path)
 
@@ -85,5 +84,43 @@ class TestGetApi(TestCase):
                 'mode': 'wrong_mode',
                 'name': 'MyAPI',
                 'url': 'https://example.com',
+            }
+            get_api(options)
+
+    def test_endpoint_prefix_max_endpoint_prefix_conflict(self):
+        with self.assertRaises(BadConfigError):
+            options = {
+                'mode': 'find_by_tag_content',
+                'name': 'MyApi',
+                'url': 'http://example.com/',
+                'multiproject': False,
+                'content_template': '{verb} {command}',
+                'endpoint_prefix': '/v2/',
+                'max_endpoint_prefix': True
+            }
+            get_api(options)
+
+    def test_endpoint_prefix_max_empty_endpoint_prefix_list(self):
+        with self.assertRaises(BadConfigError):
+            options = {
+                'mode': 'find_by_tag_content',
+                'name': 'MyApi',
+                'url': 'http://example.com/',
+                'multiproject': False,
+                'content_template': '{verb} {command}',
+                'endpoint_prefix_list': [],
+                'max_endpoint_prefix': True
+            }
+            get_api(options)
+
+    def test_endpoint_prefix_max_without_endpoint_prefix_list(self):
+        with self.assertRaises(BadConfigError):
+            options = {
+                'mode': 'find_by_tag_content',
+                'name': 'MyApi',
+                'url': 'http://example.com/',
+                'multiproject': False,
+                'content_template': '{verb} {command}',
+                'max_endpoint_prefix': True
             }
             get_api(options)


### PR DESCRIPTION
Доработки для apireference, чтобы препроцессор подставлял максимальную версию к методу, если у метода не указана версия, и если в справочнике у этого метода есть сразу несколько версий.

Что сделал:

**Добавил новую опцию `max_endpoint_prefix`.**
Данная опция не будет работать вместе с опцией `endpoint_prefix`, так как опции противоречат друг другу. Опция `endpoint_prefix` устанавливает конкретную версию, которую нужно подставить методам справочника. А опция `max_endpoint_prefix` анализирует  реестр и подставляет максимальную, а не фиксированную.

Опция `max_endpoint_prefix` работает в связке с опцией 'endpoint_prefix_list'. Это нужно для того, чтобы у препроцессора сразу был скоуп версий которые надо проверять.

В код добавлены соответствующие проверки:

- чтобы не использовались одновременно `endpoint_prefix` и `max_endpoint_prefix`;
- чтобы не использовалась `max_endpoint_prefix` и пустой 'endpoint_prefix_list'.

**Новая опция работает только с двумя режимами:**

- find_by_anchor
- find_by_tag_content

Принцип работы новой опции:

1. Префиксы версий из endpoint_prefix_list сортируются по убыванию.
2. Для каждого префикса версии создается временная ссылка с добавлением текущего префикса.
3. Проверяется наличие метода в реестре для каждой версии, начиная с самой высокой.
4. Используется первая найденная (максимальная) версия.